### PR TITLE
 Updated version and SHA

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2021.6.0" %}
+{% set version = "2021.7.0" %}
 {% set name = "fsspec" %}
-{% set sha256 = "931961514c67acab86519ca16985491e639ebf992dbc3a1aae24d44202b52426" %}
+{% set sha256 = "792ebd3b54de0b30f1ce73f0ba0a8bcc864724f2d9f248cb8d0ece47db0cbde8" %}
 
 package:
   name: fsspec


### PR DESCRIPTION
 Updated  **fsspec** version to 2021.7.0 and SHA.

Requirements from https://github.com/intake/filesystem_spec/blob/master/setup.py

This version is needed for s3fs 2021.7.0