### PR TITLE
update filesystem-spec to version 2021.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.8.3" %}
+{% set version = "2021.8.1" %}
 {% set name = "fsspec" %}
-{% set sha256 = "aad96c98b7f73bc437bb024e7cb3b0943c61049f95d6c5edec5b8b8850fd0875" %}
+{% set sha256 = "af125917788b77782899bbd4484d29e5407f53d2bb04cdfa025fe4931201a555" %}
 
 package:
   name: fsspec
@@ -18,21 +18,27 @@ build:
 
 requirements:
   host:
-    - python >=3.5
+    - python >=3.6
     - pip
     - jinja2
   run:
-    - python >=3.5
+    - python >=3.6
 
 test:
+  requires:
+    - pip
   imports:
     - fsspec
+  commands:
+    - pip check
 
 about:
   home: https://github.com/martindurant/filesystem_spec
   license: BSD-3-Clause
   license_file: LICENSE
   summary: A specification for pythonic filesystems
+  dev_url: https://github.com/intake/filesystem_spec
+  doc_url: https://filesystem-spec.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
1. check the upstream
2. updated the pinnings
  - python 3.5 to python 3.6

3. check the changelog
https://filesystem-spec.readthedocs.io/en/latest/changelog.html
There were no breaking changes mentioned on the changelog

There were some enhancements mentioned:
    HTTP get_file/put_file APIs now support callbacks (#731)
    New HTTP put_file method for transferring data to the remote server (chunked) (#731)
    Customizable HTTP client initializers (through passing `get_client` argument) (#731, #701)
    Support for various checksum / fingerprint headers in HTTP `info()` (#731)
    local implementation of rm_file (#736)
    local speed improvements (#711)
    sharing options in SMB (#706)
    streaming cat/get for ftp (#700)

There were also some fixes mentioned:
    check for remote directory when putting (#737)
    storage_option update handling (#734)
    await HTTP call before checking status (#726)
    ftp connect (#722)
    bytes conversion of times in mapper (#721)
    variable overwrite in WholeFileCache cat (#719)
    http file size again (#718)
    rm and create directories in ftp (#716, #703)
    list of files in async put (#713)
    bytes to dict in cat (#710)

4. added  pip check
5. fix test section

6. package test
    In order to test the package the following command was used: 
    `conda-build filesystem-spec-feedstock --test`

    The test results were the following:
    `All tests passed`
    
    Addtional tests:
     The package was tested on concourse to make sure the application can build in all platforms

    To make sure the package can be used properly as a dependency we used the `dask-core` package to test the `filesystem-spec` package.

    We changed the pinnings on `dask-core` so that version 2021.8.1 of `filesystem-spec` is used. 
    In order to run the test on `dask-core` the following command was used:
    `conda-build dask-core-feedstock --test`

    The result was as the following:
    `All tests passed`

7. additional research
    There are no open issues in conda-forge a the time of the review
    https://github.com/conda-forge/filesystem-spec-feedstock/issues

Based on the results of the research and on the test results we can conclude that it is safe to update the package to version 
