### PR TITLE
Update to 2021.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   noarch: python
   script: {{ PYTHON }}  -m pip install . --no-deps --ignore-installed -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2021.8.1" %}
+{% set version = "2021.10.1" %}
 {% set name = "fsspec" %}
-{% set sha256 = "af125917788b77782899bbd4484d29e5407f53d2bb04cdfa025fe4931201a555" %}
+{% set sha256 = "c245626e3cb8de5cd91485840b215a385fa6f2b0f6ab87978305e99e2d842753" %}
 
 
 package:
@@ -19,17 +19,18 @@ build:
 
 requirements:
   host:
-    - python >=3.6
-    - pip
-    - wheel
-    - setuptools
+    - python
     - jinja2
+    - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
 
 test:
   requires:
     - pip
+    - python <3.10
   imports:
     - fsspec
   commands:


### PR DESCRIPTION
Update fsspec to 2021.10.1

Actions:
1. Add `python <3.10` to test/requires
2. Rearrange host dependencies alphabetically