### PR TITLE
Update from 2022.2.0 to 2022.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2022.2.0" %}
+{% set version = "2022.3.0" %}
 {% set name = "fsspec" %}
-{% set sha256 = "20322c659538501f52f6caa73b08b2ff570b7e8ea30a86559721d090e473ad5c" %}
+{% set sha256 = "fd582cc4aa0db5968bad9317cae513450eddd08b2193c4428d9349265a995523" %}
 
 
 package:
@@ -35,16 +35,18 @@ test:
     - fsspec
     - fsspec.implementations
   commands:
-    - pip check
+    - pip check || true   # [not win]
+    - pip check || 1      # [win]
 
 about:
-  home: https://github.com/martindurant/filesystem_spec
+  home: https://github.com/fsspec/filesystem_spec
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD
   summary: A specification for pythonic filesystems
-  dev_url: https://github.com/intake/filesystem_spec
+  dev_url: https://github.com/fsspec/filesystem_spec
   doc_url: https://filesystem-spec.readthedocs.io
+  doc_source_url: https://github.com/fsspec/filesystem_spec/tree/master/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
-  noarch: python
   script: {{ PYTHON }}  -m pip install . --no-deps --ignore-installed -vv
 
 requirements:


### PR DESCRIPTION
Changelog: https://github.com/fsspec/filesystem_spec/blob/2022.3.0/docs/source/changelog.rst
Changes: https://github.com/fsspec/filesystem_spec/compare/2022.02.0...2022.3.0
License: https://github.com/fsspec/filesystem_spec/blob/2022.3.0/LICENSE
Requirements: https://github.com/fsspec/filesystem_spec/blob/2022.3.0/setup.py
Jira: https://anaconda.atlassian.net/browse/DSNC-4804

Actions:
- Update version to 2022.3.0
- Remove noarch
- Ignore pip check return (not that there is an issue with the current check)
- Update urls in meta section