### PR TITLE
Update from version 2022.3.0 to 2022.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2022.3.0" %}
+{% set version = "2022.7.1" %}
 {% set name = "fsspec" %}
-{% set sha256 = "fd582cc4aa0db5968bad9317cae513450eddd08b2193c4428d9349265a995523" %}
+{% set sha256 = "7f9fb19d811b027b97c4636c6073eb53bc4cbee2d3c4b33fa88b9f26906fd7d7" %}
 
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ about:
   license_family: BSD
   summary: A specification for pythonic filesystems
   dev_url: https://github.com/fsspec/filesystem_spec
-  doc_url: https://filesystem-spec.readthedocs.io
+  doc_url: https://filesystem-spec.readthedocs.io/en/latest/
   doc_source_url: https://github.com/fsspec/filesystem_spec/tree/master/docs
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.7
+    - python
 
 test:
   requires:


### PR DESCRIPTION
Changelog: https://github.com/fsspec/filesystem_spec/blob/2022.7.1/docs/source/changelog.rst
Changes: https://github.com/fsspec/filesystem_spec/compare/2022.3.0...2022.7.1
License: https://github.com/fsspec/filesystem_spec/blob/2022.7.1/LICENSE
Requirements: https://github.com/fsspec/filesystem_spec/blob/2022.7.1/setup.py
Jira: https://anaconda.atlassian.net/browse/DSNC-5117

Actions:
* Update to version 2022.7.1
* Remove python version redundancy in recipe
* Update `doc_url`