### PR TITLE
filesystem-spec 2022.10.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  scrass_org: s3fs

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  scrass_org: s3fs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,10 +38,15 @@ test:
     - pip check || 1      # [win]
 
 about:
+  description : |
+    To produce a template or specification for a file-system interface, that specific implementations should follow, 
+    so that applications making use of them can rely on a common behaviour and not have to worry about the specific 
+    internal implementation decisions with any given backend.
   home: https://github.com/fsspec/filesystem_spec
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD
+  license_url: https://github.com/fsspec/filesystem_spec/blob/master/LICENSE
   summary: A specification for pythonic filesystems
   dev_url: https://github.com/fsspec/filesystem_spec
   doc_url: https://filesystem-spec.readthedocs.io/en/latest/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2022.7.1" %}
+{% set version = "2022.10.0" %}
 {% set name = "fsspec" %}
-{% set sha256 = "7f9fb19d811b027b97c4636c6073eb53bc4cbee2d3c4b33fa88b9f26906fd7d7" %}
+{% set sha256 = "cb6092474e90487a51de768170f3afa50ca8982c26150a59072b16433879ff1d" %}
 
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,7 @@ test:
     - fsspec
     - fsspec.implementations
   commands:
-    - pip check || true   # [not win]
-    - pip check || 1      # [win]
+    - pip check
 
 about:
   description : |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ build:
 requirements:
   host:
     - python
-    - jinja2
     - pip
     - setuptools
     - wheel


### PR DESCRIPTION
s3fs 2020.10 --> filesystem-spec 2022.10.0

Jira ticket: https://anaconda.atlassian.net/browse/PKG-154
Upstream repo: https://github.com/fsspec/filesystem_spec
Changelog: https://github.com/fsspec/filesystem_spec/blob/2022.10.0/docs/source/changelog.rst