### PR TITLE
2022.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,13 +44,14 @@ about:
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD
-  license_url: https://github.com/fsspec/filesystem_spec/blob/master/LICENSE
   summary: A specification for pythonic filesystems
   dev_url: https://github.com/fsspec/filesystem_spec
   doc_url: https://filesystem-spec.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/fsspec/filesystem_spec/tree/master/docs
 
 extra:
   recipe-maintainers:
     - martindurant
     - TomAugspurger
+  skip-lints:
+    - missing_doc_source_url
+    - missing_license_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ about:
   license_family: BSD
   summary: A specification for pythonic filesystems
   dev_url: https://github.com/fsspec/filesystem_spec
-  doc_url: https://filesystem-spec.readthedocs.io/en/latest/
+  doc_url: https://filesystem-spec.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2022.10.0" %}
+{% set version = "2022.11.0" %}
 {% set name = "fsspec" %}
-{% set sha256 = "cb6092474e90487a51de768170f3afa50ca8982c26150a59072b16433879ff1d" %}
+{% set sha256 = "259d5fd5c8e756ff2ea72f42e7613c32667dc2049a4ac3d84364a7ca034acb8b" %}
 
 
 package:


### PR DESCRIPTION
# fsspec 2022.11.0

upstream: https://github.com/fsspec/filesystem_spec/tree/2022.11.0
jira: https://anaconda.atlassian.net/browse/PKG-780
`setup.py`: https://github.com/fsspec/filesystem_spec/blob/2022.11.0/setup.py
`requirements.txt`: https://github.com/fsspec/filesystem_spec/blob/2022.11.0/requirements.txt
changelog: https://github.com/fsspec/filesystem_spec/compare/2022.10.0...2022.11.0

## Changes
- Update version and SHA
- Minor cleanup of about section