### PR TITLE
update fsspec to 2023.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "fsspec" %}
-{% set version = "2023.9.2" %}
-{% set sha256 = "bf064186cd8808f0b2f6517273339ba0a0c8fb1b7048991c28bc67f58b8b67cd" %}
+{% set version = "2023.10.0" %}
+{% set sha256 = "330c66757591df346ad3091a53bd907e15348c2ba17d63fd54f5c39c4457d2a5" %}
 
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "fsspec" %}
 {% set version = "2023.10.0" %}
-{% set sha256 = "330c66757591df346ad3091a53bd907e15348c2ba17d63fd54f5c39c4457d2a5" %}
 
 
 package:
@@ -9,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 80bfb8c70cc27b2178cc62a935ecf242fc6e8c3fb801f9c571fc01b1e715ba7d
+  sha256: 330c66757591df346ad3091a53bd907e15348c2ba17d63fd54f5c39c4457d2a5
 
 build:
   number: 0


### PR DESCRIPTION
Changes:
- Update to 2023.10.0 (reason, for s3fs)

https://github.com/fsspec/filesystem_spec/blob/2023.10.0/setup.py