### PR TITLE
fsspec 2024.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,14 @@
 {% set name = "fsspec" %}
-{% set version = "2023.10.0" %}
+{% set version = "2024.3.1" %}
 
 
 package:
-  name: fsspec
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 330c66757591df346ad3091a53bd907e15348c2ba17d63fd54f5c39c4457d2a5
+  sha256: f39780e282d7d117ffb42bb96992f8a90795e4d0fb0f661a70ca39fe9c43ded9
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4620](https://anaconda.atlassian.net/browse/PKG-4620) 
Changelog: diff https://github.com/fsspec/filesystem_spec/compare/2023.10.0...2024.3.1
License: https://github.com/fsspec/filesystem_spec/blob/master/LICENSE
Requirements: https://github.com/fsspec/filesystem_spec/blob/2024.3.1/setup.py

### Explanation of changes:

-  No changes

### Notes:

- The build order of fsspec 2024.3.1:
botocore 1.34.69 ->
  -> boto3 1.34.69
  -> aiobotocore 2.12.3 -> [s3fs 2024.3.1 <- fsspec 2024.3.1]
  -> s3transfer 0.10.1

[PKG-4620]: https://anaconda.atlassian.net/browse/PKG-4620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ