### PR TITLE
filesystem-spec 2025.7.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fsspec" %}
-{% set version = "2025.5.1" %}
+{% set version = "2025.7.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/filesystem_spec/archive/refs/tags/{{ version }}.tar.gz
-  sha256: a71eacc36f0a5cefcd8c7b0754cba1970a51e4d6c9b1a6c08ecc9ad01923acd5
+  sha256: 7d9e29f6a8b55caf945d59bb96c8c0642f773752b5b4afe2c953fbca47074156
 
 build:
   number: 0
@@ -44,6 +44,7 @@ test:
     - fsspec.spec
     - fsspec.transaction
     - fsspec.utils
+    - fsspec.parquet
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"


### PR DESCRIPTION
filesystem-spec 2025.7.0 

**Destination channel:** Defaults

### Links

- [PKG-9028]
- dev_url:        https://github.com/fsspec/filesystem_spec/tree/2025.7.0
- conda_forge:    https://github.com/conda-forge/filesystem-spec-feedstock
- pypi:           https://pypi.org/project/fsspec/2025.7.0
- pypi inspector: https://inspector.pypi.io/project/fsspec/2025.7.0

### Explanation of changes:

- new version number


[PKG-9028]: https://anaconda.atlassian.net/browse/PKG-9028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ