### PR TITLE
fsspec 2026.6.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fsspec" %}
-{% set version = "2026.4.0" %}
+{% set version = "2026.6.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/filesystem_spec/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 233343cd47f62bb3b2c191dd9b680b3770ac648235ecfdee5f21c5d54abf1dfc
+  sha256: 22bf4df50243bc7b1f724e6adf3831f6f7c7932e975e982c00903aba1a07ae01
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,8 @@ test:
     - aiohttp !=4.0.0a0,!=4.0.0a1
     - requests
     - numpy
+    # tests rely on linux bash stat behavior, add package on OSX for behavior matching that of linux
+    - coreutils  # [osx]
 
 about:
   home: https://github.com/fsspec/filesystem_spec


### PR DESCRIPTION
fsspec 2026.6.0 

**Destination channel:** Defaults

### Links

- [PKG-15576]
- dev_url:        https://github.com/fsspec/filesystem_spec/tree/2026.6.0
- conda_forge:    https://github.com/conda-forge/filesystem-spec-feedstock
- pypi:           https://pypi.org/project/fsspec/2026.6.0
- pypi inspector: https://inspector.pypi.io/project/fsspec/2026.6.0

### Explanation of changes:

- new version number


[PKG-15576]: https://anaconda.atlassian.net/browse/PKG-15576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ